### PR TITLE
Removed uTOF::Channel TObject inheritance, do not store index

### DIFF
--- a/src/dataFormat/Channel.cxx
+++ b/src/dataFormat/Channel.cxx
@@ -4,15 +4,15 @@
 namespace uTOF {
 
   Channel::Channel() :
-    TObject(), mIndex(-1), mHits()
+    mIndex(-1), mHits()
   {}
 
   Channel::Channel(int aIndex) :
-    TObject(), mIndex(aIndex), mHits()
+    mIndex(aIndex), mHits()
   {}
 
   Channel::Channel(const Channel &rhs) :
-    TObject(rhs), mIndex(rhs.mIndex), mHits(rhs.mHits)
+    mIndex(rhs.mIndex), mHits(rhs.mHits)
   {}
 
   Channel::~Channel()
@@ -24,7 +24,6 @@ namespace uTOF {
   Channel::operator=(const Channel &rhs)
   {
     if (&rhs == this) return *this;
-    TObject::operator=(rhs);
     mIndex = rhs.mIndex;
     mHits  = rhs.mHits;
     return *this;

--- a/src/dataFormat/Channel.h
+++ b/src/dataFormat/Channel.h
@@ -1,7 +1,6 @@
 #ifndef uTOF_Channel_H
 #define uTOF_Channel_H
 
-#include "TObject.h"
 #include <vector>
 
 namespace uTOF {
@@ -9,7 +8,7 @@ namespace uTOF {
   class Hit;
   typedef std::vector<Hit *> HitArray;
 
-  class Channel : public TObject {
+  class Channel {
     
   public:
     
@@ -25,7 +24,7 @@ namespace uTOF {
     Channel &operator=(const Channel &rhs);
 
     /** accessors **/
-    Int_t      getIndex()         const {return mIndex;};
+    int        getIndex()       const {return mIndex;};
     const Hit *getHit(int iHit) const {return iHit < mHits.size() ? mHits.at(iHit) : NULL;};
 
     /** modifiers **/
@@ -35,11 +34,9 @@ namespace uTOF {
   private:
     
     /** members **/ 
-    int      mIndex;
+    int      mIndex; //!
     HitArray mHits;
     
-    ClassDef(Channel, 1);
-
   };
   
 } /** namespace uTOF **/


### PR DESCRIPTION
This will save a bit of space on disk